### PR TITLE
[#3] add retry wrapper and support retry for examples/lookup_client

### DIFF
--- a/core/util/retry_wrapper.go
+++ b/core/util/retry_wrapper.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"github.com/wondywang/rpclookup/core/lg"
+	"math/rand"
+	"time"
+)
+
+//support
+
+var logger *lg.Logger
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+//most retry time: 3^attempts * sleep
+func Retry(attempts int, sleep time.Duration, f func() error) error {
+	if err := f(); err != nil {
+		if s, ok := err.(stop); ok {
+			// Return the original error for later checking
+			return s.error
+		}
+		if attempts--; attempts > 0 {
+			// Add some randomness to prevent creating a Thundering Herd
+			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			sleep = sleep + jitter/2
+			time.Sleep(sleep)
+			return Retry(attempts, 2*sleep, f)
+		}
+		return err
+	}
+	return nil
+}
+
+type stop struct {
+	error
+}

--- a/core/util/retry_wrapper_test.go
+++ b/core/util/retry_wrapper_test.go
@@ -1,0 +1,3 @@
+package util
+
+


### PR DESCRIPTION
* add retry wrapper to support those condition which need to retry, network connection for example.
* example/lookup_client support network connection retry for 3 times start from 1 second.
* rename some variable name to represent their meaning precisely.